### PR TITLE
Support Existing Projects

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -51,9 +51,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
       this.prompt({
         name: 'name',
         message: 'What is the name of your project?',
-        default: function() {
-          return this._.humanize( this.existing && this.existing.name || path.basename(process.cwd()) )
-        }.bind(this),
+        default: this._.humanize( this.existing && this.existing.name || path.basename(process.cwd()) ),
       }, function( answers ) {
         this.humanName = answers.name;
         this.slugname = this._.slugify( answers.name );

--- a/app/index.js
+++ b/app/index.js
@@ -27,6 +27,13 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
     greet: function() {
       this.pkg = require('../package.json');
+      this.existing = function() {
+        try {
+          var manifest = require(path.join(process.cwd(), 'package.json'));
+          return manifest;
+        } catch(e) {};
+      }
+
       banner();
       this.log('\nTo learn about Capital Framework, visit ' + chalk.bold('capitalframework.com') + '\n');
     }
@@ -37,10 +44,14 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
     askForName: function() {
       var done = this.async();
+      var existing = this.existing();
+
       this.prompt({
         name: 'name',
         message: 'What is the name of your project?',
-        default: this._.humanize( path.basename(process.cwd()) ),
+        default: function() {
+          return this._.humanize( existing.name || path.basename(process.cwd()) )
+        }.bind(this),
       }, function( answers ) {
         this.humanName = answers.name;
         this.slugname = this._.slugify( answers.name );
@@ -54,30 +65,32 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
     askForDescription: function() {
       var done = this.async();
+      var existing = this.existing();
+
       var prompts = [{
         name: 'description',
         message: 'Project\'s description',
-        default: 'The best website ever.'
+        default: existing.description || 'The best website ever.'
       }, {
         name: 'homepage',
         message: 'Project\'s homepage',
-        default: 'http://www.consumerfinance.gov/'
+        default: existing.homepage || 'http://www.consumerfinance.gov/'
       }, {
         name: 'license',
         message: 'Project\'s license',
-        default: 'CC0'
+        default: existing.license || 'CC0'
       }, {
         name: 'authorName',
         message: 'Author\'s name',
-        default: 'Consumer Financial Protection Bureau'
+        default: existing.author.name || 'Consumer Financial Protection Bureau'
       }, {
         name: 'authorEmail',
         message: 'Author\'s email',
-        default: 'tech@cfpb.gov'
+        default: existing.author.email || 'tech@cfpb.gov'
       }, {
         name: 'authorUrl',
         message: 'Author\'s homepage',
-        default: 'https://cfpb.github.io/'
+        default: existing.author.url || 'https://cfpb.github.io/'
       }];
       this.prompt(prompts, function ( answers ) {
         this.currentYear = ( new Date() ).getFullYear();
@@ -150,7 +163,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         // Remove everything at the screenshot line and above.
         // ([\s\S.]*) selects everything before the end of the line that ends with screenshot.png)
         readme = readme.replace( /([\s\S.]*)screenshot\.png\)/ig, projectText );
-        // If this isn't a public domain project, remove all the licensing info 
+        // If this isn't a public domain project, remove all the licensing info
         // from the bottom of the README.
         if ( this.props.license !== 'CC0' ) {
           readme = readme.replace(/([\s\n\r]*)## Open source licensing info([\s\S]*)/ig, '');

--- a/app/index.js
+++ b/app/index.js
@@ -21,18 +21,21 @@ var components = request({
   headers: {'user-agent': 'generator-cf'}
 }).then( filterComponents ).catch( console.error );
 
+var manifestCheck = function() {
+  try {
+    var manifest = require(path.join(process.cwd(), 'package.json'));
+
+    return manifest;
+  } catch(e) {};
+};
+
 var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
   initializing: {
 
     greet: function() {
       this.pkg = require('../package.json');
-      this.existing = function() {
-        try {
-          var manifest = require(path.join(process.cwd(), 'package.json'));
-          return manifest;
-        } catch(e) {};
-      }
+      this.existing = manifestCheck();
 
       banner();
       this.log('\nTo learn about Capital Framework, visit ' + chalk.bold('capitalframework.com') + '\n');
@@ -44,13 +47,12 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
     askForName: function() {
       var done = this.async();
-      var existing = this.existing();
 
       this.prompt({
         name: 'name',
         message: 'What is the name of your project?',
         default: function() {
-          return this._.humanize( existing.name || path.basename(process.cwd()) )
+          return this._.humanize( this.existing && this.existing.name || path.basename(process.cwd()) )
         }.bind(this),
       }, function( answers ) {
         this.humanName = answers.name;
@@ -65,32 +67,31 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
     askForDescription: function() {
       var done = this.async();
-      var existing = this.existing();
 
       var prompts = [{
         name: 'description',
         message: 'Project\'s description',
-        default: existing.description || 'The best website ever.'
+        default: this.existing && this.existing.description || 'The best website ever.'
       }, {
         name: 'homepage',
         message: 'Project\'s homepage',
-        default: existing.homepage || 'http://www.consumerfinance.gov/'
+        default: this.existing && this.existing.homepage || 'http://www.consumerfinance.gov/'
       }, {
         name: 'license',
         message: 'Project\'s license',
-        default: existing.license || 'CC0'
+        default: this.existing && this.existing.license || 'CC0'
       }, {
         name: 'authorName',
         message: 'Author\'s name',
-        default: existing.author.name || 'Consumer Financial Protection Bureau'
+        default: this.existing && this.existing.author && this.existing.author.name || 'Consumer Financial Protection Bureau'
       }, {
         name: 'authorEmail',
         message: 'Author\'s email',
-        default: existing.author.email || 'tech@cfpb.gov'
+        default: this.existing && this.existing.author && this.existing.author.email || 'tech@cfpb.gov'
       }, {
         name: 'authorUrl',
         message: 'Author\'s homepage',
-        default: existing.author.url || 'https://cfpb.github.io/'
+        default: this.existing && this.existing.author && this.existing.author.url || 'https://cfpb.github.io/'
       }];
       this.prompt(prompts, function ( answers ) {
         this.currentYear = ( new Date() ).getFullYear();


### PR DESCRIPTION
Added check for an existing project

## Additions

None

## Removals

None

## Changes

- Checks if a project already exists by searching for a local package.json
- If project exists, generator uses the manifest properties as prompt defaults
- If a project doesn't exist, defaults to the suggested prompt defaults

## Testing

- fetch and run `npm link`
- run `yo cf` on an empty directory to test original defaults but create new answers
- run `yo cf` again on same directory and defaults should be updated to previously created answers

## Review

- @contolini 
- @ascott1 
- @Scotchester 

## Preview

None

## Notes

- I'm also working on a PR to check for a non-standard installation location (such as what cfgov-refresh uses), but that's a bit wider scope.