### PR TITLE
Adds details for project repository info

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -79,6 +79,14 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         message: 'Project\'s license',
         default: this.existing && this.existing.license || 'CC0'
       }, {
+        name: 'repoType',
+        message: 'Repository type',
+        default: this.existing && this.existing.repository && this.existing.repository.type || 'git'
+      }, {
+        name: 'repoUrl',
+        message: 'Repository URL',
+        default: this.existing && this.existing.repository && this.existing.repository.url || 'https://github.com/cfpb/capital-framework.git'
+      }, {
         name: 'authorName',
         message: 'Author\'s name',
         default: this.existing && this.existing.author && this.existing.author.name || 'Consumer Financial Protection Bureau'

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -11,8 +11,8 @@
     } %>
   },
   "repository": {
-    "type": "git",
-    "url": "https://github.com/cfpb/capital-framework.git"
+    "type": "<%= props.repoType %>",
+    "url": "<%= props.repoUrl %>"
   },
   "license": "<%= props.license %>",
   "dependencies": {

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -10,6 +10,10 @@
         "url": "<%= props.authorUrl %>" <%
     } %>
   },
+  "repository": {
+    "type": "<%= props.repoType %>",
+    "url": "<%= props.repoUrl %>"
+  },
   "license": "<%= props.license %>",
   "keywords": [
     "<%= slugname %>"

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -24,6 +24,7 @@ describe('cf generator', function () {
       '.bowerrc',
       '.gitignore',
       'bower.json',
+      'package.json',
       'Gruntfile.js'
     ];
     helpers.mockPrompt(this.app, {


### PR DESCRIPTION
Adds details for project repository info

## Additions

None

## Removals

None

## Changes

- Adds new prompts for repo type and repo url
- Adds repo placeholders in bower.json and package.json templates
- Adds package.json to mocha test

## Testing

- fetch and run `npm link`
- run `yo cf` on an empty directory adding your own repo details when prompted
- run `yo cf` again on same directory and repo defaults should be updated to previously created answers
- run `mocha` to test for existence of `package.json`

## Review

- @contolini 
- @ascott1 
- @Scotchester 

## Preview

![screen shot 2015-03-24 at 11 51 27 am](https://cloud.githubusercontent.com/assets/1280430/6805928/2737c192-d21c-11e4-84dd-9a41bbe52021.png)


## Notes

- Fixes #4 
- Fixes #44 