### PR TITLE
Removed errant whitespace when including an author's url

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -5,10 +5,8 @@
   <% if (props.homepage) { %>"homepage": "<%= props.homepage %>",<% } %>
   "author": {
     "name": "<%= props.authorName %>",
-    "email": "<%= props.authorEmail %>" <%
-    if (props.authorUrl) { %> ,
-        "url": "<%= props.authorUrl %>" <%
-    } %>
+    "email": "<%= props.authorEmail %>"<% if (props.authorUrl) { %>,
+    "url": "<%= props.authorUrl %>"<% } %>
   },
   "repository": {
     "type": "git",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,10 +5,8 @@
   <% if (props.homepage) { %>"homepage": "<%= props.homepage %>",<% } %>
   "author": {
     "name": "<%= props.authorName %>",
-    "email": "<%= props.authorEmail %>" <%
-    if (props.authorUrl) { %> ,
-        "url": "<%= props.authorUrl %>" <%
-    } %>
+    "email": "<%= props.authorEmail %>"<% if (props.authorUrl) { %>,
+    "url": "<%= props.authorUrl %>"<% } %>
   },
   "license": "<%= props.license %>",
   "keywords": [


### PR DESCRIPTION
Removes errant whitespace when including an author's url

## Additions

None

## Removals

None

## Changes

- Made author url conditions inline in both manifest templates

## Testing

- fetch and run `npm link`
- run `mocha`
- check `/test/temp/bower.json` for any errant whitespace around the author url

## Review

- @contolini 
- @ascott1 
- @Scotchester 

## Preview

__Before__
![screen shot 2015-03-24 at 12 03 55 pm](https://cloud.githubusercontent.com/assets/1280430/6806323/579ff870-d21e-11e4-85f4-f69ce9a7e3fb.png)

__After__
![screen shot 2015-03-24 at 12 04 23 pm](https://cloud.githubusercontent.com/assets/1280430/6806327/5c389cf2-d21e-11e4-806f-289b9c09d513.png)

## Notes

- Fixes #41 