### PR TITLE
Adds cf-core to bower dependency list

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -104,13 +104,13 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         this.prompt({
           type: 'checkbox',
           name: 'components',
-          message: 'Which CF components would you like in your app?',
+          message: 'You’re about to install CF Core. Which additional CF components would you like in your app?',
           choices: components,
           default: components.map( function( c ) {
             return c.value;
           })
         }, function ( answers ) {
-          this.components = answers.components;
+          this.components = answers.components.push('cf-core');
           done();
         }.bind(this));
       }.bind(this));


### PR DESCRIPTION
Adds cf-core to bower dependency list
 
## Additions
 
None
 
## Removals
 
None
 
## Changes
 
- manually added cf-core to list of user component options
- updated components message to clarify what steps the user is about to take
 
## Testing
 
- fetch and run npm link
- run yo cf and include cf-core when prompted for component options
- check `bower.json` for cf-core as listed dep
- check `/src/vendor` for cf-core for proper installation
 
## Review
 
- @Scotchester 
- @himedlooff 
- @contolini 
- @ascott1 
 
## Preview
 
![screen shot 2015-03-24 at 5 10 53 pm](https://cloud.githubusercontent.com/assets/1280430/6813017/c45050f8-d248-11e4-8c1a-2e5676103452.png)
 
## Notes
 
- Including cf-core in the project deps adds clarity to the project
- Fixes #42 