### PR TITLE
Update the generated README

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -193,6 +193,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
           .pipe( fs.createWriteStream(file) );
       }.bind(this));
 
+      this.template('_README.md', 'README.md');
       this.template('_package.json', 'package.json');
       this.template('_bower.json', 'bower.json');
       this.template('_Gruntfile.js', 'Gruntfile.js');
@@ -206,22 +207,6 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
       this.template('src/static/css/main.less', 'src/static/css/main.less');
       this.copy('src/index.html', 'src/index.html');
       this.mkdir('dist');
-    },
-
-    processReadme: function() {
-        // The README that comes from OSPT doesn't include template variables so
-        // we have to manually regex what we want out of it.
-        var readme = this.readFileAsString( this.destinationRoot() + '/_cache/open-source-project-template-master/README.md'),
-            projectText = '# ' + this.humanName + '\r\n\r\n' + this.props.description + '\r\n\r\n![Screenshot](screenshot.png)';
-        // Remove everything at the screenshot line and above.
-        // ([\s\S.]*) selects everything before the end of the line that ends with screenshot.png)
-        readme = readme.replace( /([\s\S.]*)screenshot\.png\)/ig, projectText );
-        // If this isn't a public domain project, remove all the licensing info
-        // from the bottom of the README.
-        if ( this.props.license !== 'CC0' ) {
-          readme = readme.replace(/([\s\n\r]*)## Open source licensing info([\s\S]*)/ig, '');
-        }
-        this.writeFileFromString( readme, 'README.md' );
     },
 
     processGitIgnore: function() {

--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -1,0 +1,111 @@
+# <%= humanName %>
+
+<%= props.description %>
+
+![Screenshot](screenshot.png)
+
+## Dependencies
+
+- [Grunt](http://gruntjs.com): task runner for pulling in assets,
+  linting and concatenating code, etc.
+- [Bower](http://bower.io): Package manager for front-end dependencies.
+- [Less](http://lesscss.org): CSS pre-processor.
+- [Capital Framework](https://cfpb.github.io/capital-framework/getting-started):
+  User interface pattern-library produced by the CFPB.
+
+**NOTE:** If you're new to Capital Framework, we encourage you to
+[start here](https://cfpb.github.io/capital-framework/getting-started).
+
+## Installation
+
+1. Install [Node.js](http://nodejs.org) however you'd like.
+2. Install [Grunt](http://gruntjs.com) and [Bower](http://bower.io):
+  ```bash
+  npm install -g grunt-cli bower
+  ```
+3. Next, install the dependencies and compile the project with:
+  ```bash
+  ./setup.sh
+  ```
+  __NOTE:__ To re-install and rebuild all the site’s assets run
+  `./setup.sh` again. See the [usage](#usage) section on updating all the
+  project dependencies.
+
+## Configuration
+
+_If the software is configurable, describe it in detail,
+either here or in other documentation to which you link._
+
+## Usage
+
+Each time you fetch from the upstream repository (this repo), run `./setup.sh`.
+This setup script will remove and re-install the project dependencies and
+rebuild the site's JavaScript and CSS assets.
+
+To watch for changes in the source code and automatically update the running site,
+open a terminal and run:
+
+```bash
+grunt watch
+```
+
+Alternatively, if you don't want to run the full watch task,
+there are three available sub-tasks:
+
+```bash
+# Watch & compile CSS only
+grunt watch:css
+
+# Watch & compile JS only
+grunt watch:js
+
+# Watch & compile CSS & JS only
+grunt watch:cssjs
+```
+
+## How to test the software
+
+After running `./setup.sh` or compiling with Grunt,
+you can view the site in a browser by opening `/dist/index.html`.
+Alternatively, you may want to use a local server with something like
+`python -m SimpleHTTPServer`.
+
+## Known issues
+
+_Document any known significant shortcomings with the software._
+
+## Getting help
+
+_Instruct users how to get help with this software; this might include links
+to an issue tracker, wiki, mailing list, etc._
+
+Use the issue tracker to follow the development conversation.
+If you find a bug not listed in the issue tracker, please file a bug report.
+
+## Getting involved
+
+We welcome your feedback and contributions. See the
+[contribution guidelines](https://github.com/cfpb/open-source-project-template/blob/master/CONTRIBUTING.md)
+for more details.
+
+Additionally, you may want to consider
+[contributing to the Capital Framework](https://cfpb.github.io/capital-framework/contributing/),
+which is the front-end pattern library used in this project.
+
+
+----
+
+## Open source licensing info
+1. [TERMS](TERMS.md)
+2. [LICENSE](LICENSE)
+3. [CFPB Source Code Policy](https://github.com/cfpb/source-code-policy/)
+
+
+----
+
+## Credits and references
+
+1. Projects that inspired you
+2. Related projects
+3. Books, papers, talks, or other sources that have meaniginful impact or
+   influence on this project


### PR DESCRIPTION
Update the generated README with dependencies and installation instructions

## Additions

None

## Removals

None

## Changes

- utilizes a README template for known content (borrowing from cfgov-refresh)
- grabs the OSPT README for everything from configuration down
- combines the two for a SUPER README

## Testing

- fetch and run `npm link`
- run `mocha`
- check /test/temp/README.md for new SUPER README content

## Review

- @contolini 
- @ascott1 
- @Scotchester 
- @KimberlyMunoz
- @himedlooff 

## Preview

![screen shot 2015-03-24 at 6 15 38 pm](https://cloud.githubusercontent.com/assets/1280430/6814069/ce9de10c-d251-11e4-919c-cff5e439fd29.png)

## Notes

- Open to suggestions for the dependencies and instructions. These just seemed like a good starting place
- Fixes #37 