### PR TITLE
Switching GitHub API to search endpoint

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -16,7 +16,7 @@ updateNotifier();
 
 // Grab a list of all CF components, we'll use it later.
 var components = request({
-  uri: 'https://api.github.com/orgs/cfpb/repos?per_page=100',
+  uri: 'https://api.github.com/search/repositories?q=%22cf-%22+NOT+cfpb+NOT+cfgov+NOT+deprecated+NOT+generator+user:cfpb+language:JavaScript+language:css+language:html',
   json: true,
   headers: {'user-agent': 'generator-cf'}
 }).then( filterComponents ).catch( console.error );

--- a/app/lib/filter-components.js
+++ b/app/lib/filter-components.js
@@ -2,26 +2,19 @@ var ignore = require('./ignore.json');
 var frameworkComponents = [];
 
 function getCfComponents( data ) {
-  data.forEach( function(el, i) {
+  data.items.forEach( function(el, i) {
 
     var name;
-    // Does it start with "cf-"?
-    var startsWithCf = el.name.indexOf('cf-') === 0;
     // Is it listed in the ignore.json file?
     var ignoreIt = ignore.indexOf( el.name ) >= 0;
-    // Is the word deprecated in the description?
-    var isDeprecated = el.description.toLowerCase().indexOf('deprecated') >= 0;
-    // Has GitHub determined its language (meaning it's probably not an empty repo.)?
-    var hasLanguage = el.language !== null;
 
-    if ( startsWithCf && !ignoreIt && !isDeprecated && hasLanguage ) {
+    if ( !ignoreIt ) {
       name = el.name.replace( 'cf-', '' );
       frameworkComponents.push({
         name: name.charAt(0).toUpperCase() + name.slice(1),
         value: el.name
       });
     }
-
   });
   // Sort them alphabetically
   return frameworkComponents.sort( function( a, b ) {


### PR DESCRIPTION
Switching GitHub API to search endpoint for better speed and simplicity

## Additions

None

## Removals

None

## Changes

- updated API url to search enpoint with filtering params included
- updated filter components to use new json object (repos are now in a child array of `items`)

## Testing

- fetch and run `npm link`
- run `yo cf` in a test project directory
- should be a noticeable difference in initial app ramp up time
- same components as always should be displayed at prompt

## Review

- @contolini 
- @ascott1 
- @Scotchester 
- @KimberlyMunoz
- @himedlooff 

## Preview

None

## Notes

- using search endpoint reduces total number of requests (we now have over 100 repos)
- using search endpoint greatly reduces request times (removes about 1-2 sec from initial ramp up)
- using search endpoint allows us to push the filtering on to GitHub rather than our app’s logic
- **mocha tests not available due to components not being written to `bower.json` (see #52)**