### PR TITLE
Aligns brand palette with official palette

### DIFF
--- a/app/templates/src/static/css/brand-palette.less
+++ b/app/templates/src/static/css/brand-palette.less
@@ -3,28 +3,69 @@
    Color variables
    ========================================================================== */
 
-// Official Palette as of October 29, 2013 (Brand 2.0)
+// Official palette.
+// Current as of April 9, 2015.
+// To view the colors in the Design Manual, visit:
+// https://cfpb.github.io/design-manual/identity/color-principles.html#palette
 
-@green: #2CB34A;
-@green-midtone: #ADDC91;
-@green-tint: #DBEDD4;
+// Primary colors:
 
-@white: #FFFFFF;
-@black: #101820;
-@darkgray: #43484E;
+@green:             #2CB34A;
+@green-midtone:     #ADDC91;
+@green-tint:        #DBEDD4;
 
-// Base                 // 80% Tint                // 50% Tint                // 20% Tint
-@redorange: #D12124;    @redorange-80: #DA6750;    @redorange-50: #E8A091;    @redorange-20: #F6D9D3;
-@gold: #FF9E1B;         @gold-80: #FFB149;         @gold-50: #FFCE8D;         @gold-20: #FFECD1;
-@neutral: #796E65;      @neutral-80: #948B84;      @neutral-50: #BCB6B2;      @neutral-20: #E4E2E0;
-@navy: #002D72;         @navy-80: #33578E;         @navy-50: #7F96B8;         @navy-20: #CCD5E3;
-@pacific: #0072CE;      @pacific-80: #328ED8;      @pacific-50: #7FB8E6;      @pacific-20: #CCE3F5;
-@teal: #005E5D;         @teal-80: #337E7D;         @teal-50: #7FAEAE;         @teal-20: #CCDFDF;
+@black:             #101820;
 
-@gray: #75787B;         @gray-80: #919395;         @gray-50: #BABBBD;         @gray-20: #E3E4E5;
-                                                                              @gray-10: #F1F2F2;
-                                                                              @gray-5: #F8F8F8;
 
-// Unofficial or proposed colors
+// Background colors:
 
-@dark-redorange: #9C301B; // Needed for active state of destructive action buttons
+@darkgray:          #43484E;
+
+@gray:              #75787B;
+@gray-80:           #919395;
+@gray-50:           #BABBBD;
+@gray-20:           #E3E4E5;
+@gray-10:           #F1F2F2;
+@gray-5:            #F8F8F8;
+
+
+// Secondary colors:
+
+@redorange:         #D12124;
+@redorange-80:      #DA6750;
+@redorange-50:      #E8A091;
+@redorange-20:      #F6D9D3;
+
+@gold:              #FF9E1B;
+@gold-80:           #FFB149;
+@gold-50:           #FFCE8D;
+@gold-20:           #FFECD1;
+
+@neutral:           #796E65;
+@neutral-80:        #948B84;
+@neutral-50:        #BCB6B2;
+@neutral-20:        #E4E2E0;
+
+@navy:              #002D72;
+@navy-80:           #33578E;
+@navy-50:           #7F96B8;
+@navy-20:           #CCD5E3;
+
+@pacific:           #0072CE;
+@pacific-80:        #328ED8;
+@pacific-50:        #7FB8E6;
+@pacific-20:        #CCE3F5;
+
+@teal:              #005E5D;
+@teal-80:           #337E7D;
+@teal-50:           #7FAEAE;
+@teal-20:           #CCDFDF;
+
+
+// Unofficial colors not part of the official palette,
+// but are in use for easier coding semantics or UX needs.
+
+// Active state of destructive action buttons.
+@dark-redorange:    #9C301B;
+
+@white:             #FFF;


### PR DESCRIPTION
Formats `brand-palette.less` to follow format and order shown in http://cfpb.github.io/design-manual/identity/color-principles.html#palette.

## Additions

- Adds reference to official palette in design handbook (fixes #59).

## Removals

- Removes `Brand 2.0` reference as this didn't seem to mean anything in this context.

## Changes

- Moves `@white` to unofficial color group because it's not included as a swatch in the official palette.
- Groups colors by primary, background, and secondary groupings as used in the official palette.
- Changes layout from multi-column to single-column, since multi-column didn't accommodate tints beyond 20% (such as gray 10% and 5%), and also risks going over 80 characters per line.

## Testing

- No change.

## Review

- @Scotchester
- @contolini
- @ascott1
- @jimmynotjim 
- @KimberlyMunoz