### PR TITLE
Template changes to keep dependencies out of source control

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -35,9 +35,9 @@ module.exports = function(grunt) {
           cleanTargetDir: false,
           layout: function(type, component) {
             if (type === 'img') {
-              return path.join('../static/img');
+              return path.join('static/img');
             } else if (type === 'fonts') {
-              return path.join('../static/fonts');
+              return path.join('static/fonts');
             } else {
               return path.join(component);
             }
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
           '!<%%= loc.src %>/vendor/cf-core/*.less',
           '<%%= loc.src %>/vendor/cf-core/cf-core.less'
         ],
-        dest: '<%%= loc.src %>/static/css/capital-framework.less',
+        dest: '<%%= loc.src %>/vendor/capital-framework/capital-framework.less',
       },
       js: {
         src: [
@@ -230,8 +230,9 @@ module.exports = function(grunt) {
             expand: true,
             cwd: '<%%= loc.src %>/static',
             src: [
-              // Fonts
-              'fonts/*'
+              // Static assets
+              'fonts/*',
+              'img/*'
             ],
             dest: '<%%= loc.dist %>/static'
           },
@@ -241,7 +242,10 @@ module.exports = function(grunt) {
             src: [
               // Vendor files
               'vendor/html5shiv/html5shiv-printshiv.min.js',
-              'vendor/box-sizing-polyfill/boxsizing.htc'
+              'vendor/box-sizing-polyfill/boxsizing.htc',
+              // Vendor static assets
+              'vendor/static/fonts/*',
+              'vendor/static/img/*'
             ],
             dest: '<%%= loc.dist %>/static'
           }

--- a/app/templates/src/static/css/main.less
+++ b/app/templates/src/static/css/main.less
@@ -10,7 +10,7 @@
 @import (less) "../../vendor/normalize-legacy-addon/normalize-legacy-addon.css";
 
 // Import the combined Capital Framework component file that was created by `grunt compile-cf`.
-@import (less) "capital-framework.less";
+@import (less) "../../vendor/capital-framework/capital-framework.less";
 
 // Import the brand color palette.
 @import (less) "brand-palette.less";

--- a/app/templates/src/static/css/main.less
+++ b/app/templates/src/static/css/main.less
@@ -19,7 +19,7 @@
 @import (less) "cf-theme-overrides.less";
 
 // Import the Capital Framework enhancements
-@import (less) "cf-enhancements.less"
+@import (less) "cf-enhancements.less";
 
 // We've generated some sample rules for you. They're used with the index.html file.
 // Please delete them before starting your project.


### PR DESCRIPTION
- Moves concatenated Capital Framework Less to
  `/src/vendor/capital-framework/capital-framework.less`
- Updates `grunt:bower` task to collect static assets from Bower
  dependencies in a `static` folder within `/src/vendor`
- Adds a `grunt:copy` subtask for copying stuff from
  `/src/vendor/static/` to `/dist/static/`

Closes #55