### PR TITLE
Generalizes lintjs task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## Unreleased – Unreleased
+
+## Additions
+
+- Adds `lintjs` task.
+- Adds `--quiet` CLI flag to Gruntfile to suppress warnings in linter.
+
+## Changes
+
+- Supersedes `eslint` task by `lintjs`.
+
 
 ## 0.6.0 – 2015-04-20
 

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -10,6 +10,15 @@ module.exports = function(grunt) {
   });
 
   var path = require('path');
+
+  // Allows a `--quiet` flag to be passed to Grunt from the command-line.
+  // If the flag is present the value is true, otherwise it is false.
+  // This flag can be used to, for example, suppress warning output
+  // from linters.
+  var env = {
+    quiet: grunt.option('quiet') ? true : false
+  };
+
   var config = {
 
     /**
@@ -258,15 +267,22 @@ module.exports = function(grunt) {
     },
 
     /**
-     * ESLint: https://github.com/sindresorhus/grunt-eslint
-     *
-     * Validate files with ESLint.
+     * Lint the JavaScript.
      */
-    eslint: {
-      target: [
-        // 'Gruntfile.js', // uncomment to lint the Gruntfle
-        '<%%= loc.src %>/static/js/app.js'
-      ]
+    lintjs: {
+      /**
+       * Validate files with ESLint.
+       * https://www.npmjs.com/package/grunt-contrib-eslint
+       */
+      eslint: {
+        options: {
+          quiet: env.quiet
+        },
+        src: [
+          // 'Gruntfile.js', // Uncomment to lint the Gruntfile.
+          '<%%= loc.src %>/static/js/app.js'
+        ]
+      }
     },
 
     /**
@@ -295,7 +311,11 @@ module.exports = function(grunt) {
   grunt.registerTask('compile-cf', ['bower:cf', 'concat:cf-less']);
   grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css']);
   grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js']);
-  grunt.registerTask('test', ['eslint']);
+  grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
+  grunt.registerMultiTask('lintjs', 'Lint the JavaScript', function(){
+    grunt.config.set(this.target, this.data);
+    grunt.task.run(this.target);
+  });
   grunt.registerTask('build', ['test', 'css', 'js', 'copy']);
   grunt.registerTask('default', ['build']);
 


### PR DESCRIPTION
Generalizes lintjs task from `grunt eslint` to `grunt lintjs`. 

## Additions

- Adds `lintjs` task.
- Adds `--quiet` CLI flag to Gruntfile to suppress warnings in linter.

## Changes

- Supersedes `eslint` task by `lintjs`.

## Testing

- Generate a new CF project and run `grunt lintjs`, `grunt test`, `grunt lintjs --quiet`, and `grunt test --quiet`

## Review

- @ascott1
- @Scotchester 
- @contolini 

## Notes

- ESLint is broken per https://github.com/cfpb/generator-cf/issues/78, but the grunt task should still be able to be run.