### PR TITLE
Update generator logic to support CF v1.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,25 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## Unreleased – Unreleased
+## 1.0.0 – 2015-06-02
 
-## Additions
+### Changed
+- Supersedes `eslint` task by `lintjs`.
+- If user selects every component, install capital-framework instead of every
+  component individually.
+- Fixes async bug that was preventing final goodbye message from being echoed.
+- Updated all dev dependencies in package.json to latest versions.
 
+## Added
 - Adds `lintjs` task.
 - Adds `--quiet` CLI flag to Gruntfile to suppress warnings in linter.
+- Checks author's email to determine if they're a CFPB employee and uncomments
+  licensed-fonts.css if they are.
+- Adds `clean` task to delete the dist dir before recreating it.
 
-## Changes
-
-- Supersedes `eslint` task by `lintjs`.
+### Removed
+- Grunt bower and concat-cf tasks.
+- `exportsOverride` section in bower.json.
 
 
 ## 0.7.0 - 2015-05-19

--- a/app/index.js
+++ b/app/index.js
@@ -111,6 +111,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         default: this.existing && this.existing.author && this.existing.author.url || 'https://cfpb.github.io/'
       }];
       this.prompt(prompts, function ( answers ) {
+        this.isCfpbEmployee = answers.authorEmail.indexOf('cfpb.gov') > -1;
         this.currentYear = ( new Date() ).getFullYear();
         this.props = answers;
         done();
@@ -138,11 +139,17 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
               json: true,
               headers: { 'user-agent': 'generator-cf'}
             }, function( err, res, data ) {
-              versionedComponents.push({ 'name': repo, 'ver': data[0].name });
+              versionedComponents.push({ 'name': repo, 'ver': '^' + data[0].name });
             }).catch( console.error );
           };
 
-          answers.components.push('cf-core');
+          // If they selected every component, install the general 
+          // capital-framework component instead of every individual component.
+          if (components.length === answers.components.length) {
+            answers.components = ['capital-framework'];
+          } else {
+            answers.components.push('cf-core');
+          }
 
           answers.components.forEach( function(el) {
             getLatest(el);
@@ -235,7 +242,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
       if ( this.options['skip-install'] ) return;
 
-      var done = this._.after( 2, this.async() );
+      var done = this.async();
 
       this.npmInstall( '', {}, done );
 
@@ -245,7 +252,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
   end: {
 
-    bye: function(){
+    bye: function() {
       this.log( yosay('All done! Edit the files in the src directory and then `grunt build` to compile everything into the dist directory.') );
     }
 

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -26,50 +26,16 @@ module.exports = function(grunt) {
     },
 
     /**
-     * Bower: https://github.com/yatskevich/grunt-bower-task
-     *
-     * Set up Bower packages and migrate static assets.
-     */
-    bower: {
-      cf: {
-        options: {
-          targetDir: '<%%= loc.src %>/vendor/',
-          install: false,
-          verbose: true,
-          cleanTargetDir: false,
-          layout: function(type, component) {
-            if (type === 'img') {
-              return path.join('static/img');
-            } else if (type === 'fonts') {
-              return path.join('static/fonts');
-            } else {
-              return path.join(component);
-            }
-          }
-        }
-      }
-    },
-
-    /**
      * Concat: https://github.com/gruntjs/grunt-contrib-concat
      *
      * Concatenate cf-* Less files prior to compiling them.
      */
     concat: {
-      'cf-less': {
-        src: [
-          '<%%= loc.src %>/vendor/cf-*/*.less',
-          '!<%%= loc.src %>/vendor/cf-core/*.less',
-          '<%%= loc.src %>/vendor/cf-core/cf-core.less'
-        ],
-        dest: '<%%= loc.src %>/vendor/capital-framework/capital-framework.less',
-      },
       js: {
         src: [
-          '<%%= loc.src %>/vendor/jquery/jquery.js',
-          '<%%= loc.src %>/vendor/jquery.easing/jquery.easing.js',
-          '<%%= loc.src %>/vendor/cf-*/*.js',
-          '!<%%= loc.src %>/vendor/cf-*/Gruntfile.js',
+          '<%%= loc.src %>/vendor/jquery/dist/jquery.js',
+          '<%%= loc.src %>/vendor/jquery.easing/js/jquery.easing.js',
+          '<%%= loc.src %>/vendor/cf-*/src/js/*.js',
           '<%%= loc.src %>/static/js/app.js'
         ],
         dest: '<%%= loc.dist %>/static/js/main.js'
@@ -214,6 +180,13 @@ module.exports = function(grunt) {
     },
 
     /**
+     * Clean: https://github.com/gruntjs/grunt-contrib-clean
+     *
+     * Clean files and folders
+     */
+    clean: ['dist'],
+
+    /**
      * Copy: https://github.com/gruntjs/grunt-contrib-copy
      *
      * Copy files and folders.
@@ -232,24 +205,20 @@ module.exports = function(grunt) {
           },
           {
             expand: true,
-            cwd: '<%%= loc.src %>/static',
+            flatten: true,
+            cwd: '<%%= loc.src %>',
             src: [
-              // Static assets
-              'fonts/*',
-              'img/*'
+              // Fonts
+              'vendor/cf-icons/src/fonts/*'
             ],
-            dest: '<%%= loc.dist %>/static'
+            dest: '<%%= loc.dist %>/static/fonts'
           },
           {
             expand: true,
             cwd: '<%%= loc.src %>',
             src: [
               // Vendor files
-              'vendor/html5shiv/html5shiv-printshiv.min.js',
               'vendor/box-sizing-polyfill/boxsizing.htc',
-              // Vendor static assets
-              'vendor/static/fonts/*',
-              'vendor/static/img/*'
             ],
             dest: '<%%= loc.dist %>/static'
           }
@@ -292,11 +261,10 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases and combinations.
    */
-  grunt.registerTask('compile-cf', ['bower:cf', 'concat:cf-less']);
   grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css']);
   grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js']);
   grunt.registerTask('test', ['eslint']);
-  grunt.registerTask('build', ['test', 'css', 'js', 'copy']);
+  grunt.registerTask('build', ['clean', 'css', 'js', 'copy']);
   grunt.registerTask('default', ['build']);
 
 };

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -279,7 +279,7 @@ module.exports = function(grunt) {
    */
   grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css']);
   grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js']);
-  grunt.registerTask('test', ['lintjs', 'mocha_istanbul']);
+  grunt.registerTask('test', ['lintjs']);
   grunt.registerMultiTask('lintjs', 'Lint the JavaScript', function(){
     grunt.config.set(this.target, this.data);
     grunt.task.run(this.target);

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -15,22 +15,5 @@
   "license": "<%= props.license %>",
   "dependencies": { <% for(var i=0; i<components.length; i++) { %>
     "<%= components[i].name %>": "<%= components[i].ver%>"<% if (i < components.length - 1) { %>,<% } %><% } %>
-  },
-  "exportsOverride": {
-    "cf-*": {
-      "css": "src/**/*.css",
-      "less": "src/**/*.less",
-      "fonts": "src/fonts/*.*",
-      "js": "src/**/*.js"
-    },
-    "box-sizing-polyfill": {
-      "js": "boxsizing.htc"
-    },
-    "html5shiv": {
-      "js": "dist/html5shiv-printshiv.min.js"
-    },
-    "jquery.easing": {
-      "js": "js/jquery.easing.js"
-    }
   }
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -18,24 +18,25 @@
   ],
   "devDependencies": {
     "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~2.0.0",
-    "grunt-banner": "~0.2.3",
+    "grunt-autoprefixer": "~3.0.1",
+    "grunt-banner": "~0.4.0",
     "grunt-bower-task": "~0.4.0",
     "grunt-concurrent": "~1.0.0",
-    "grunt-contrib-concat": "~0.5.0",
-    "grunt-contrib-copy": "~0.7.0",
-    "grunt-contrib-cssmin": "~0.10.0",
-    "grunt-eslint": "^11.0.0",
-    "grunt-contrib-less": "~0.12.0",
-    "grunt-contrib-uglify": "^0.6.0",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-concat": "~0.5.1",
+    "grunt-contrib-copy": "~0.8.0",
+    "grunt-contrib-cssmin": "~0.12.3",
+    "grunt-contrib-less": "~1.0.1",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6.1",
+    "grunt-eslint": "^14.0.0",
     "grunt-legacssy": "~0.4.0",
-    "grunt-string-replace": "~1.0.0",
+    "grunt-string-replace": "~1.2.0",
     "grunt-topdoc": "~0.3.0",
     "jit-grunt": "~0.9.1",
-    "time-grunt": "~1.0.0"
+    "time-grunt": "~1.2.1"
   },
   "scripts": {
-    "postinstall": "bower install && grunt compile-cf"
+    "postinstall": "bower install"
   }
 }

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -37,6 +37,7 @@
     "time-grunt": "~1.2.1"
   },
   "scripts": {
+    "test": "grunt test",
     "postinstall": "bower install"
   }
 }

--- a/app/templates/src/static/css/main.less
+++ b/app/templates/src/static/css/main.less
@@ -9,16 +9,16 @@
 @import (less) "../../vendor/normalize-css/normalize.css";
 @import (less) "../../vendor/normalize-legacy-addon/normalize-legacy-addon.css";
 
-// Import the combined Capital Framework component file that was created by `grunt compile-cf`.
-@import (less) "../../vendor/capital-framework/capital-framework.less";
-
+// Import Capital Framework.
+<% for(var i=0; i<components.length; i++) { %>@import (less) "../../vendor/<%= components[i].name %>/src/<%= components[i].name %>.less";
+<% } %>
 // Import the brand color palette.
 @import (less) "brand-palette.less";
 
 // Uncomment to import Avenir font on CFPB projects.
 // If this project is on a non-CFPB domain,
 // use this file as a template for adding web fonts.
-//@import (less) 'licensed-fonts.css';
+<% if (!isCfpbEmployee) { %>//<% } %>@import (less) 'licensed-fonts.css';
 
 // Override the Capital Framework theme variables with colors from the brand color palette.
 @import (less) "cf-theme-overrides.less";


### PR DESCRIPTION
Uses the new `@import` technique instead of concatenating the `cf-` files.

## Added
- Checks author's email to determine if they're a CFPB employee and uncomments licensed-fonts.css if they are.
- Adds `clean` task to delete the dist dir before recreating it.

### Changed
- If user selects every component, install capital-framework instead of every component individually.
- Fixes async bug that was preventing final goodbye message from being echoed.
- Updated all dev dependencies in package.json to latest versions.
- Adds carets in front of CF components' version numbers in bower.json.
- Updates changelog appropriately.

### Removed
- Grunt bower and concat-cf tasks.
- `exportsOverride` section in bower.json.

## Testing

- Pull down these changes and follow the [contributing steps](https://github.com/cfpb/generator-cf#contributing).
- Generate a new project. Provide an author's email of "foo@bar.com" and select all available CF components. The generated `src/static/css/main.less` file should:
  - Have `@import (less) 'licensed-fonts.css'` commented out because it doesn't think you're a CFPB employee.
  - Import `"../../vendor/capital-framework/src/capital-framework.less"` because it knows you want the entire framework.
- Generate a new project. Provide your CFPB email as the author's email and select only one or two CF components. The generated `src/static/css/main.less` file should:
  - Have `@import (less) 'licensed-fonts.css'` NOT commented out because it detected "cfpb.gov" in your email address and assumes you're a CFPBer.
  - Import each selected component on a separate line.

## Review

- @Scotchester 
- @jimmynotjim 
- @anselmbradford 

## Notes

This PR has some strong opinions. Notably, the removal of the grunt bower task and related `exportsOverride` section of bower.json. That grunt task has always felt ugly and esoteric to me. It's not easy to determine what it does without studying the task's docs.

The result is that the directories in `src/vendor` are now populated with the full contents of the dependencies' repos instead of just their "main" files. I don't view this as a problem because it's Bower's default behavior and it's how other managers like npm do it. I know others liked that task, though, so please voice any concerns.