### PR TITLE
Stop importing normalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 1.0.1 – 2015-07-08
+
+### Removed
+- Normalize.css imports.
+
 ## 1.0.0 – 2015-06-02
 
 ### Changed

--- a/app/templates/src/static/css/main.less
+++ b/app/templates/src/static/css/main.less
@@ -5,10 +5,6 @@
 // This is your project's main Less file.
 // Project-specific Less rules go after the imports.
 
-// Import Normalize, a Capital Framework dependency and an all-around best practice.
-@import (less) "../../vendor/normalize-css/normalize.css";
-@import (less) "../../vendor/normalize-legacy-addon/normalize-legacy-addon.css";
-
 // Import Capital Framework.
 <% for(var i=0; i<components.length; i++) { %>@import (less) "../../vendor/<%= components[i].name %>/src/<%= components[i].name %>.less";
 <% } %>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-cf",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Capital Framework Yeoman generator",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
[cf-core now does it](https://github.com/cfpb/cf-core/blob/gh-pages/src/cf-core.less#L7-L8).

## Removals

- Normalize.css import rule in main.less

## Review

- @sephcoster