### PR TITLE
Update some cf-theme-overrides.less default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,29 @@
-# Changelog
+# Change Log
 
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
+
+
+## 1.1.1 – 2015-08-27
+
+### Changed
+- Set default `@grid_wrapper-width` in `cf-theme-overrides.less` to 1230px.
+  (@cfpb/design-manual#342)
+- Set default `@expandable-group-divider` to `@gray-50`.
+  (@cfpb/design-manual#143)
+
 
 ## 1.1.0 – 2015-08-03
 
 ### Added
 - `setup.sh` script.
 
+
 ## 1.0.1 – 2015-07-08
 
 ### Removed
 - Normalize.css imports.
+
 
 ## 1.0.0 – 2015-06-02
 

--- a/app/templates/src/static/css/cf-theme-overrides.less
+++ b/app/templates/src/static/css/cf-theme-overrides.less
@@ -112,7 +112,7 @@
 @expandable-group_header-text:  @gray;
 @expandable-group_header-bg:    @gray-10;
 @expandable-group-bg:           @white;
-@expandable-group-divider:      @gray-80;
+@expandable-group-divider:      @gray-50;
 
 // Sizing variables
 
@@ -144,7 +144,7 @@
    ========================================================================== */
 
 @grid_box-sizing-polyfill-path: '/static/vendor/box-sizing-polyfill';
-@grid_wrapper-width:            1200px;
+@grid_wrapper-width:            1230px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;
 @grid_debug:                    false;

--- a/app/templates/src/static/css/cf-theme-overrides.less
+++ b/app/templates/src/static/css/cf-theme-overrides.less
@@ -16,10 +16,10 @@
 
 // Font variables
 
-@webfont-regular: 'AvenirNextLTW01-Regular';
-@webfont-italic: 'AvenirNextLTW01-Italic';
-@webfont-medium: 'AvenirNextLTW01-Medium';
-@webfont-demi: 'AvenirNextLTW01-Demi';
+@webfont-regular:               'AvenirNextLTW01-Regular';
+@webfont-italic:                'AvenirNextLTW01-Italic';
+@webfont-medium:                'AvenirNextLTW01-Medium';
+@webfont-demi:                  'AvenirNextLTW01-Demi';
 
 // Color variables
 
@@ -111,7 +111,7 @@
 // .expandable-group
 @expandable-group_header-text:  @gray;
 @expandable-group_header-bg:    @gray-10;
-@expandable-group-bg: @white;
+@expandable-group-bg:           @white;
 @expandable-group-divider:      @gray-80;
 
 // Sizing variables
@@ -244,4 +244,3 @@
 
 // .list__branded
 @list__branded-bullet:          @green;
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-cf",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Capital Framework Yeoman generator",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
- Set default `@grid_wrapper-width` in `cf-theme-overrides.less` to 1230px. (cfpb/design-manual#342)
- Set default `@expandable-group-divider` to `@gray-50`. (cfpb/design-manual#143)

## Review
- @cfpb/front-end-team-admin 