### PR TITLE
Update template's grunt-eslint dependency version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-less": "~1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-eslint": "^16.0.0",
+    "grunt-eslint": "^17.1.0",
     "grunt-legacssy": "~0.4.0",
     "grunt-string-replace": "~1.2.0",
     "grunt-topdoc": "~0.3.0",


### PR DESCRIPTION
To support changes in eslint 1.0.0 that have been incorporated into our `.eslintrc` file that is pulled in from cfpb/front-end.