### PR TITLE
Removed cf-tables from ignore.json

### DIFF
--- a/app/lib/ignore.json
+++ b/app/lib/ignore.json
@@ -2,7 +2,6 @@
   "cf-component-demo",
   "cf-grunt-config",
   "cf-tabs",
-  "cf-tables",
   "cf-demo",
   "cf-colors",
   "cf-core"


### PR DESCRIPTION
Removing `cf-tables` from the `ignore.json` to ensure cf-tables is picked up by the generator.

## Removals
- Removed `cf-tables` from `ignore.json`

## Review
- @Scotchester @ascott1 @contolini - do you mind checking this over?

## Checklist
* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)

## Special Thanks
Thanks to @ascott1, @Scotchester, and @contolini for advice on CF!

## Animated GIF
Removing tables is like:

![table-break](https://cloud.githubusercontent.com/assets/1490703/9856307/d04a3c58-5ae1-11e5-8275-f676a4716a5a.gif)
