### PR TITLE
Updated grunt-eslint to 17.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 1.1.2 - 2015-09-28
+- Updated grunt-eslint in template from `17.1.0` to `17.2.0`.
+
 
 ## 1.1.1 – 2015-08-27
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-less": "~1.0.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-eslint": "^17.1.0",
+    "grunt-eslint": "^17.2.0",
     "grunt-legacssy": "~0.4.0",
     "grunt-string-replace": "~1.2.0",
     "grunt-topdoc": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-cf",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Capital Framework Yeoman generator",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
Updates grunt-eslint in the template to the latest.

## Changes

- Updated grunt-eslint in template from `17.1.0` to `17.2.0`.

## Testing

- generate a project, ESLint should pass when run.

## Review

- @Scotchester 
