### PR TITLE
Improve generated build processes

### DIFF
--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -8,8 +8,6 @@ module.exports = function(grunt) {
     usebanner: 'grunt-banner'
   });
 
-  var path = require('path');
-
   // Allows a `--quiet` flag to be passed to Grunt from the command-line.
   // If the flag is present the value is true, otherwise it is false.
   // This flag can be used to, for example, suppress warning output
@@ -224,12 +222,12 @@ module.exports = function(grunt) {
           },
           {
             expand: true,
-            cwd: '<%= loc.src %>/static',
+            cwd: '<%%= loc.src %>/static',
             src: [
               // Images
               'img/**'
             ],
-            dest: '<%= loc.dist %>/static'
+            dest: '<%%= loc.dist %>/static'
           },
           {
             expand: true,
@@ -272,15 +270,15 @@ module.exports = function(grunt) {
      */
     watch: {
       css: {
-        files: ['<%= loc.src %>/static/css/**/*.less'],
+        files: ['<%%= loc.src %>/static/css/**/*.less'],
         tasks: ['css']
       },
       js: {
-        files: ['Gruntfile.js', '<%= loc.src %>/static/js/**/*.js'],
+        files: ['Gruntfile.js', '<%%= loc.src %>/static/js/**/*.js'],
         tasks: ['js']
       },
       html: {
-        files: ['<%= loc.src %>/**/*.html'],
+        files: ['<%%= loc.src %>/**/*.html'],
         tasks: ['copy:dist']
       }
     }

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -5,7 +5,6 @@ module.exports = function(grunt) {
   require('time-grunt')(grunt);
   require('jit-grunt')(grunt, {
     // Static mappings below; needed because task name does not match package name
-    bower: 'grunt-bower-task',
     usebanner: 'grunt-banner'
   });
 
@@ -37,7 +36,7 @@ module.exports = function(grunt) {
     /**
      * Concat: https://github.com/gruntjs/grunt-contrib-concat
      *
-     * Concatenate cf-* Less files prior to compiling them.
+     * Concatenate cf-* JS files prior to compiling them.
      */
     concat: {
       js: {
@@ -201,14 +200,15 @@ module.exports = function(grunt) {
      * Copy files and folders.
      */
     copy: {
-      main: {
+      dist: {
         files: [
           {
             expand: true,
             cwd: '<%%= loc.src %>',
             src: [
               // HTML files
-              '*.html',
+              '**/*.html',
+              '!**/vendor/**'
             ],
             dest: '<%%= loc.dist %>'
           },
@@ -224,10 +224,20 @@ module.exports = function(grunt) {
           },
           {
             expand: true,
+            cwd: '<%= loc.src %>/static',
+            src: [
+              // Images
+              'img/**'
+            ],
+            dest: '<%= loc.dist %>/static'
+          },
+          {
+            expand: true,
             cwd: '<%%= loc.src %>',
             src: [
               // Vendor files
               'vendor/box-sizing-polyfill/boxsizing.htc',
+              'vendor/html5shiv/dist/html5shiv-printshiv.min.js'
             ],
             dest: '<%%= loc.dist %>/static'
           }
@@ -261,9 +271,17 @@ module.exports = function(grunt) {
      * Add files to monitor below.
      */
     watch: {
-      default: {
-        files: ['Gruntfile.js', '<%%= loc.src %>/static/css/**/*.less', '<%%= loc.src %>/static/js/**/*.js'],
-        tasks: ['default']
+      css: {
+        files: ['<%= loc.src %>/static/css/**/*.less'],
+        tasks: ['css']
+      },
+      js: {
+        files: ['Gruntfile.js', '<%= loc.src %>/static/js/**/*.js'],
+        tasks: ['js']
+      },
+      html: {
+        files: ['<%= loc.src %>/**/*.html'],
+        tasks: ['copy:dist']
       }
     }
 
@@ -277,8 +295,8 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases and combinations.
    */
-  grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css']);
-  grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js']);
+  grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css', 'copy']);
+  grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js'], 'copy');
   grunt.registerTask('test', ['lintjs']);
   grunt.registerMultiTask('lintjs', 'Lint the JavaScript', function(){
     grunt.config.set(this.target, this.data);

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -293,14 +293,14 @@ module.exports = function(grunt) {
   /**
    * Create custom task aliases and combinations.
    */
-  grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css', 'copy']);
-  grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js'], 'copy');
+  grunt.registerTask('css', ['less', 'autoprefixer', 'legacssy', 'cssmin', 'usebanner:css', 'copy:dist']);
+  grunt.registerTask('js', ['concat:js', 'uglify', 'usebanner:js'], 'copy:dist');
   grunt.registerTask('test', ['lintjs']);
   grunt.registerMultiTask('lintjs', 'Lint the JavaScript', function(){
     grunt.config.set(this.target, this.data);
     grunt.task.run(this.target);
   });
-  grunt.registerTask('build', ['test', 'clean', 'css', 'js', 'copy']);
+  grunt.registerTask('build', ['test', 'clean', 'css', 'js', 'copy:dist']);
   grunt.registerTask('default', ['build']);
 
 };

--- a/app/templates/_Gruntfile.js
+++ b/app/templates/_Gruntfile.js
@@ -34,7 +34,7 @@ module.exports = function(grunt) {
     /**
      * Concat: https://github.com/gruntjs/grunt-contrib-concat
      *
-     * Concatenate cf-* JS files prior to compiling them.
+     * Concatenate JavaScript files prior to uglifying them.
      */
     concat: {
       js: {

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -13,8 +13,7 @@
     "url": "<%= props.repoUrl %>"
   },
   "license": "<%= props.license %>",
-  "dependencies": {
-<% for(var i=0; i<components.length; i++) { %>
+  "dependencies": { <% for(var i=0; i<components.length; i++) { %>
     "<%= components[i].name %>": "<%= components[i].ver %>",<% } %>
     "html5shiv": "latest"
   }

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -13,7 +13,9 @@
     "url": "<%= props.repoUrl %>"
   },
   "license": "<%= props.license %>",
-  "dependencies": { <% for(var i=0; i<components.length; i++) { %>
-    "<%= components[i].name %>": "<%= components[i].ver%>"<% if (i < components.length - 1) { %>,<% } %><% } %>
+  "dependencies": {
+<% for(var i=0; i<components.length; i++) { %>
+    "<%= components[i].name %>": "<%= components[i].ver %>",<% } %>
+    "html5shiv": "latest"
   }
 }


### PR DESCRIPTION
- Re-adds html5shiv to the list of Bower dependencies (fixes #90)
- Fixes Grunt watch so that it only builds what is needed, depending on
  what has been changed
- Updates the copy task to include images, include HTML files in
  subfolders, exclude HTML files from dependencies, include html5shiv
- Adds `copy` to the `css` and `js` task aliases so that the changes get
  copied to `dist` after they're run.