### PR TITLE
Fix for not including cf-expandables at generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 
+### Fixed
+- Generated `main.js` no longer breaks on first run if the cf-expandables
+  component was deselected during generation.
+
 
 ## 2.0.0 - 2016-01-04
 

--- a/app/templates/grunt/_package.json
+++ b/app/templates/grunt/_package.json
@@ -18,7 +18,8 @@
   ],
   "dependencies": { <% for(var i=0; i<components.length; i++) { %>
     "<%= components[i].name %>": "<%= components[i].ver %>",<% } %>
-    "html5shiv": "latest"
+    "html5shiv": "latest",
+    "jquery": "^1.11.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/app/templates/src/static/js/main.js
+++ b/app/templates/src/static/js/main.js
@@ -1,11 +1,16 @@
 'use strict';
-<%
-  if ( components.some( function ( el ) {
-         return el.name === 'cf-expandables';
-       } ) ) {
-%>
+
+// The following line imports jQuery into your project. If you don't need jQuery, delete it.
 global.$ = require( 'jquery' );
-require( 'cf-expandables' );
+
+// If you'd like to include cf-expandables (or any other node module in your project),
+// run `npm install cf-expandables --save` and require() it in this file.
+<%
+  var isExpandables = function( el ) {
+    return el.name === 'cf-expandables';
+  }
+  if ( ! components.some( isExpandables ) ) {
+%>// <% } %>require( 'cf-expandables' );
 
 // Count all features included in the test page.
 $( '.feature-list' ).append(
@@ -18,6 +23,4 @@ $( '.feature-list' ).append(
   '<strong>' + $( '.feature-list_item' ).size() + '</strong> ' +
   'cf-components.</p>' +
   '</section>'
-);<%
-  }
-%>
+);

--- a/app/templates/src/static/js/main.js
+++ b/app/templates/src/static/js/main.js
@@ -1,5 +1,9 @@
 'use strict';
-
+<%
+  if ( components.some( function ( el ) {
+         return el.name === 'cf-expandables';
+       } ) ) {
+%>
 global.$ = require( 'jquery' );
 require( 'cf-expandables' );
 
@@ -14,4 +18,6 @@ $( '.feature-list' ).append(
   '<strong>' + $( '.feature-list_item' ).size() + '</strong> ' +
   'cf-components.</p>' +
   '</section>'
-);
+);<%
+  }
+%>


### PR DESCRIPTION
Generated `main.js` no longer breaks on first run if the cf-expandables
component was deselected during generation.

Fixes #108

**Notes:**
- The extra template markup to get this to work is ugly as sin.
  Happy to take formatting suggestions, either via comments or
  direct additional commits to this branch.

**Review:**
- @contolini
- @ascott1
- @jimmynotjim