### PR TITLE
Add missing block border variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Generated `main.js` no longer breaks on first run if the cf-expandables
   component was deselected during generation.
 - Generator no longer tries to copy `main.less` and `index.html` twice.
+- Added missing color vars for block borders to `cf-theme-enhancements.less`.
 
 
 ## 2.0.0 - 2016-01-04

--- a/app/templates/grunt/_package.json
+++ b/app/templates/grunt/_package.json
@@ -16,7 +16,7 @@
   "keywords": [
     "<%= slugname %>"
   ],
-  "dependencies": { <% for(var i=0; i<components.length; i++) { %>
+  "dependencies": {<% for(var i=0; i<components.length; i++) { %>
     "<%= components[i].name %>": "<%= components[i].ver %>",<% } %>
     "html5shiv": "latest",
     "jquery": "^1.11.0"

--- a/app/templates/src/static/css/cf-theme-overrides.less
+++ b/app/templates/src/static/css/cf-theme-overrides.less
@@ -178,10 +178,10 @@
 // .block
 @block__bg:                     @gray-10;
 @block__border:                 @gray-40;
-@block__border-top:             @gray-40;
-@block__border-right:           @gray-40;
-@block__border-bottom:          @gray-40;
-@block__border-left:            @gray-40;
+@block__border-top:             @block__border;
+@block__border-right:           @block__border;
+@block__border-bottom:          @block__border;
+@block__border-left:            @block__border;
 
 // .content_main
 @content_main-border:           @gray-40;

--- a/app/templates/src/static/css/cf-theme-overrides.less
+++ b/app/templates/src/static/css/cf-theme-overrides.less
@@ -176,9 +176,12 @@
 // Color variables
 
 // .block
-@block__border-top:             @gray-40;
-@block__border-bottom:          @gray-40;
 @block__bg:                     @gray-10;
+@block__border:                 @gray-40;
+@block__border-top:             @gray-40;
+@block__border-right:           @gray-40;
+@block__border-bottom:          @gray-40;
+@block__border-left:            @gray-40;
 
 // .content_main
 @content_main-border:           @gray-40;


### PR DESCRIPTION
A few variables corresponding to an update to cf-layout were never propagated to the overrides file.


## Testing

1. Pull changes.
2. Run `npm link` from project root directory.
3. Generate a new CF project.
4. Confirm presence of new variables in `cf-theme-overrides.less`.


## Review

- @contolini 
- @jimmynotjim 
- @ascott1 


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices 
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
