### PR TITLE
Pin dependencies in generated package.json files

### DIFF
--- a/app/templates/grunt/_package.json
+++ b/app/templates/grunt/_package.json
@@ -17,30 +17,29 @@
     "<%= slugname %>"
   ],
   "dependencies": {<% for(var i=0; i<components.length; i++) { %>
-    "<%= components[i].name %>": "<%= components[i].ver %>",<% } %>
-    "html5shiv": "latest",
-    "jquery": "^1.11.0"
+    "<%= components[i].name %>": "^<%= components[i].ver %>",<% } %>
+    "html5shiv": "3.7.3",
+    "jquery": "1.12.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-autoprefixer": "~3.0.1",
-    "grunt-banner": "~0.4.0",
-    "grunt-bower-task": "~0.4.0",
-    "grunt-browserify": "~4.0.1",
-    "grunt-concurrent": "~1.0.0",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-concat": "~0.5.1",
-    "grunt-contrib-copy": "~0.8.0",
-    "grunt-contrib-cssmin": "~0.12.3",
-    "grunt-contrib-less": "~1.0.1",
-    "grunt-contrib-uglify": "^0.9.1",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-eslint": "^17.2.0",
-    "grunt-legacssy": "~0.4.0",
-    "grunt-string-replace": "~1.2.0",
-    "grunt-topdoc": "~0.3.0",
-    "jit-grunt": "~0.9.1",
-    "time-grunt": "~1.2.1"
+    "grunt": "0.4.5",
+    "grunt-autoprefixer": "3.0.1",
+    "grunt-banner": "0.4.0",
+    "grunt-browserify": "4.0.1",
+    "grunt-concurrent": "1.0.0",
+    "grunt-contrib-clean": "0.6.0",
+    "grunt-contrib-concat": "0.5.1",
+    "grunt-contrib-copy": "0.8.0",
+    "grunt-contrib-cssmin": "0.12.3",
+    "grunt-contrib-less": "1.0.1",
+    "grunt-contrib-uglify": "0.9.1",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-eslint": "17.2.0",
+    "grunt-legacssy": "0.4.0",
+    "grunt-string-replace": "1.2.0",
+    "grunt-topdoc": "0.3.0",
+    "jit-grunt": "0.9.1",
+    "time-grunt": "1.2.1"
   },
   "scripts": {
     "test": "grunt test"

--- a/app/templates/gulp/_package.json
+++ b/app/templates/gulp/_package.json
@@ -17,33 +17,33 @@
     "<%= slugname %>"
   ],
   "dependencies": { <% for(var i=0; i<components.length; i++) { %>
-    "<%= components[i].name %>": "<%= components[i].ver %>",<% } %>
-    "html5shiv": "latest"
+    "<%= components[i].name %>": "^<%= components[i].ver %>",<% } %>
+    "html5shiv": "3.7.3"
   },
   "devDependencies": {
-    "browser-sync": "^2.8.0",
-    "del": "^1.2.0",
+    "browser-sync": "2.8.0",
+    "del": "1.2.0",
     "fs": "0.0.2",
-    "gulp": "^3.9.0",
-    "gulp-autoprefixer": "^2.3.1",
-    "gulp-changed": "^1.2.1",
-    "gulp-concat": "^2.6.0",
-    "gulp-webpack": "^1.5.0",
-    "gulp-cssmin": "^0.1.7",
-    "gulp-eslint": "^1.0.0",
-    "gulp-header": "^1.2.2",
-    "gulp-imagemin": "^2.3.0",
-    "gulp-less": "^3.0.3",
-    "gulp-load-plugins": "^1.0.0-rc.1",
+    "gulp": "3.9.0",
+    "gulp-autoprefixer": "2.3.1",
+    "gulp-changed": "1.2.1",
+    "gulp-concat": "2.6.0",
+    "gulp-webpack": "1.5.0",
+    "gulp-cssmin": "0.1.7",
+    "gulp-eslint": "1.0.0",
+    "gulp-header": "1.2.2",
+    "gulp-imagemin": "2.3.0",
+    "gulp-less": "3.0.3",
+    "gulp-load-plugins": "1.0.0-rc.1",
     "gulp-mq-remove": "0.0.2",
-    "gulp-notify": "^2.2.0",
-    "gulp-rename": "^1.2.2",
-    "gulp-replace": "^0.5.3",
-    "gulp-sourcemaps": "^1.5.2",
-    "gulp-uglify": "^1.4.1",
-    "gulp-util": "^3.0.6",
-    "jquery": "^1.11.3",
-    "pretty-hrtime": "^1.0.0",
-    "require-dir": "^0.3.0"
+    "gulp-notify": "2.2.0",
+    "gulp-rename": "1.2.2",
+    "gulp-replace": "0.5.3",
+    "gulp-sourcemaps": "1.5.2",
+    "gulp-uglify": "1.4.1",
+    "gulp-util": "3.0.6",
+    "jquery": "1.11.3",
+    "pretty-hrtime": "1.0.0",
+    "require-dir": "0.3.0"
   }
 }


### PR DESCRIPTION
This PR just removes the range characters from all non-CF dependencies in generated `package.json` files.

Let me know if you think anything needs a version bump, as well.