### PR TITLE
Minor cleanup / update gulp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
   component was deselected during generation.
 - Generator no longer tries to copy `main.less` and `index.html` twice.
 - Added missing color vars for block borders to `cf-theme-enhancements.less`.
-- Added a default `.npmrc` that will automatically save all npm installs to the `package.json` and pin the specific version installed
+- Added a default `.npmrc` that will automatically save all npm installs to the
+  `package.json` and pin the specific version installed.
+- Removed extraneous whitespace from dependencies and index.html.
+- Updated gulp to `3.9.1` from `3.9.0`.
+- Fixed max line length warnings in linter.
+- Normalized spacing in parentheses.
 
 
 ## 2.0.0 - 2016-01-04

--- a/app/index.js
+++ b/app/index.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var yeoman = require('yeoman-generator');
-var yosay = require('yosay');
-var path = require('path');
-var chalk = require('chalk');
-var banner = require('./banner');
-var request = require('request-promise');
-var filterComponents = require('./lib/filter-components');
-var updateNotifier = require('./lib/notifier');
-var fs = require('fs');
-var rimraf = require('rimraf');
-var RegClient = require('silent-npm-registry-client');
+var yeoman = require( 'yeoman-generator' );
+var yosay = require( 'yosay' );
+var path = require( 'path' );
+var chalk = require( 'chalk' );
+var banner = require( './banner' );
+var request = require( 'request-promise' );
+var filterComponents = require( './lib/filter-components' );
+var updateNotifier = require( './lib/notifier' );
+var fs = require( 'fs' );
+var rimraf = require( 'rimraf' );
+var RegClient = require( 'silent-npm-registry-client' );
 var client = new RegClient();
-var promisify = require('promisify-node');
+var promisify = require( 'promisify-node' );
 
 // Give the npm registry client a promise interface.
-promisify(client);
+promisify( client );
 
 // Alert the user if a newer version of this generator is available.
 updateNotifier();
@@ -28,26 +28,26 @@ var osLibraries = [
 ];
 
 // Grab a list of all CF components, we'll use it later.
-var components = request({
-  uri: 'https://api.github.com/repos/cfpb/capital-framework/contents/src',
-  json: true,
+var components = request( {
+  uri:     'https://api.github.com/repos/cfpb/capital-framework/contents/src',
+  json:    true,
   headers: {'user-agent': 'generator-cf'}
-}).then( filterComponents ).catch( console.error );
+} ).then( filterComponents ).catch( console.error );
 
 var manifestCheck = function() {
   try {
-    var manifest = require(path.join(process.cwd(), 'package.json'));
+    var manifest = require( path.join( process.cwd(), 'package.json' ) );
 
     return manifest;
   } catch(e) {};
 };
 
-var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
+var CapitalFrameworkGenerator = yeoman.generators.Base.extend( {
 
   initializing: {
 
     greet: function() {
-      this.pkg = require('../package.json');
+      this.pkg = require( '../package.json' );
       this.existing = manifestCheck();
 
       banner();
@@ -55,7 +55,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         '\nWelcome to the Capital Framework generator, brought\n' +
         'to you by the ' + chalk.green('Consumer Financial Protection Bureau') + '.'
       );
-      this.log('\nTo learn about Capital Framework, visit ' + chalk.bold('capitalframework.com') + '.\n');
+      this.log( '\nTo learn about Capital Framework, visit ' + chalk.bold( 'capitalframework.com' ) + '.\n' );
     }
 
   },
@@ -65,7 +65,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
     askForName: function() {
       var done = this.async();
 
-      this.prompt({
+      this.prompt( {
         name: 'name',
         message: 'What is the name of your project?',
         default: this._.humanize( this.existing && this.existing.name || path.basename(process.cwd()) ),
@@ -77,7 +77,7 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
           }
         );
         done();
-      }.bind(this));
+      }.bind( this ) );
     },
 
     askForDescription: function() {
@@ -116,44 +116,44 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         message: 'Author\'s homepage',
         default: this.existing && this.existing.author && this.existing.author.url || 'https://cfpb.github.io/'
       }];
-      this.prompt(prompts, function ( answers ) {
-        this.isCfpbEmployee = answers.authorEmail.indexOf('cfpb.gov') > -1;
+      this.prompt( prompts, function( answers ) {
+        this.isCfpbEmployee = answers.authorEmail.indexOf( 'cfpb.gov' ) > -1;
         this.currentYear = ( new Date() ).getFullYear();
         this.props = answers;
         done();
-      }.bind( this ));
+      }.bind( this ) );
     },
 
     askAboutComponents: function() {
       var done = this.async();
       components.then( function( components ) {
-        this.prompt({
-          type: 'checkbox',
-          name: 'components',
+        this.prompt( {
+          type:    'checkbox',
+          name:    'components',
           message: 'You’re about to install CF Core. Which additional CF components would you like in your app?',
           choices: components,
           default: components.map( function( c ) {
             return c.value;
-          })
-        }, function ( answers ) {
+          } )
+        }, function( answers ) {
           var versionedComponents = this.components = [];
 
           // Get latest repo tag
           var getLatest = function( repo ) {
             var uri = 'https://registry.npmjs.org/' + repo;
-            client.get( uri, { timeout: 1000 } ).then(function( data ) {
-              versionedComponents.push({ 'name': repo, 'ver': data['dist-tags'].latest });
-            }).catch( console.error );
+            client.get( uri, { timeout: 1000 } ).then( function( data ) {
+              versionedComponents.push( { 'name': repo, 'ver': data['dist-tags'].latest } );
+            } ).catch( console.error );
           };
 
-          answers.components.push('cf-core');
+          answers.components.push( 'cf-core' );
 
-          answers.components.forEach( function(el) {
-            getLatest(el);
-          });
+          answers.components.forEach( function( el ) {
+            getLatest( el );
+          } );
           done();
-        }.bind(this));
-      }.bind(this));
+        }.bind( this ) );
+      }.bind( this ) );
     },
 
     askForBuildTool: function() {
@@ -166,18 +166,18 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
         message:  'Which build tool do you prefer?',
         choices:  [
           {
-            name: 'Grunt',
+            name:  'Grunt',
             value: 'grunt'
           },
           {
-            name: 'Gulp',
+            name:  'Gulp',
             value: 'gulp'
           }
         ]
       }, function( answers ) {
         this.buildToolChoice = answers.buildToolChoice;
         done();
-      }.bind(this) );
+      }.bind( this ) );
     }
   },
 
@@ -187,9 +187,9 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
       var numLibraries = osLibraries.length;
       var done = this._.after( numLibraries, this.async() );
 
-      osLibraries.forEach(function (library) {
-        this.extract(library, '_cache', done);
-      }.bind(this));
+      osLibraries.forEach( function( library ) {
+        this.extract( library, '_cache', done );
+      }.bind( this ) );
     },
 
     appFiles: function() {
@@ -197,25 +197,27 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
 
       // If this is a public domain project, grab some more files from OSPT.
       if ( this.props.license === 'CC0' ) {
-        files = files.concat(['TERMS.md', 'CONTRIBUTING.md', 'LICENSE']);
+        files = files.concat( ['TERMS.md', 'CONTRIBUTING.md', 'LICENSE'] );
       }
 
       // Copy over the OSPT files.
+      var rootDir = this.destinationRoot() +
+                    '/_cache/open-source-project-template-master/';
       files.forEach( function _copy( file ) {
-        fs.createReadStream( this.destinationRoot() + '/_cache/open-source-project-template-master/' + file )
-          .pipe( fs.createWriteStream(file) );
-      }.bind(this));
+        fs.createReadStream( rootDir + file )
+          .pipe( fs.createWriteStream( file ) );
+      }.bind( this ) );
 
       // Copy files from the front-end repo.
       var feFiles = ['.eslintrc'];
       feFiles.forEach( function _copy( file ) {
         fs.createReadStream( this.destinationRoot() + '/_cache/front-end-master/' + file )
-          .pipe( fs.createWriteStream(file) );
-      }.bind(this));
+          .pipe( fs.createWriteStream( file ) );
+      }.bind( this ) );
 
       if ( this.buildToolChoice === 'gulp' ) {
         this.template( 'gulp/_package.json', 'package.json' );
-        this.template('gulp/_README.md', 'README.md');
+        this.template( 'gulp/_README.md', 'README.md' );
         this.copy( 'gulp/_gulpfile.js', 'gulpfile.js' );
         this.copy( 'gulp/_setup.sh', 'setup.sh' );
         this.directory( 'gulp/gulp', 'gulp' );
@@ -229,24 +231,26 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
     },
 
     srcFiles: function() {
-      this.mkdir('src');
-      this.directory('src/static', 'src/static');
-      this.template('src/index.html', 'src/index.html');
-      this.mkdir('dist');
+      this.mkdir( 'src' );
+      this.directory( 'src/static', 'src/static' );
+      this.template( 'src/index.html', 'src/index.html' );
+      this.mkdir( 'dist' );
     },
 
     processGitIgnore: function() {
-        var gitignore = this.readFileAsString( this.destinationRoot() + '/_cache/open-source-project-template-master/.gitignore'),
-            done = this.async();
-        // Add src/vendor to the end.
-        gitignore = gitignore + '\r\nsrc/vendor/';
-        this.writeFileFromString( gitignore, '.gitignore' );
-        // Kill the _cache dir.
-        rimraf( this.destinationRoot() + '/_cache', done );
+      var fileName = this.destinationRoot() +
+                     '/_cache/open-source-project-template-master/.gitignore';
+      var gitignore = this.readFileAsString( fileName );
+      var done = this.async();
+      // Add src/vendor to the end.
+      gitignore = gitignore + '\r\nsrc/vendor/';
+      this.writeFileFromString( gitignore, '.gitignore' );
+      // Kill the _cache dir.
+      rimraf( this.destinationRoot() + '/_cache', done );
     },
 
     copyNpmrc: function() {
-      this.template('_npmrc', '.npmrc');
+      this.template( '_npmrc', '.npmrc' );
     }
 
   },
@@ -268,12 +272,14 @@ var CapitalFrameworkGenerator = yeoman.generators.Base.extend({
   end: {
 
     bye: function() {
-      this.log( yosay('All done! Edit the files in the src directory and then `grunt build` to compile everything into the dist directory.') );
+      var msg = 'All done! Edit the files in the src directory and then ' +
+                '`grunt build` to compile everything into the dist directory.';
+      this.log( yosay( msg ) );
     }
 
   }
 
 
-});
+} );
 
 module.exports = CapitalFrameworkGenerator;

--- a/app/templates/gulp/_package.json
+++ b/app/templates/gulp/_package.json
@@ -16,7 +16,7 @@
   "keywords": [
     "<%= slugname %>"
   ],
-  "dependencies": { <% for(var i=0; i<components.length; i++) { %>
+  "dependencies": {<% for(var i=0; i<components.length; i++) { %>
     "<%= components[i].name %>": "^<%= components[i].ver %>",<% } %>
     "html5shiv": "3.7.3"
   },
@@ -24,7 +24,7 @@
     "browser-sync": "2.8.0",
     "del": "1.2.0",
     "fs": "0.0.2",
-    "gulp": "3.9.0",
+    "gulp": "3.9.1",
     "gulp-autoprefixer": "3.1.0",
     "gulp-changed": "1.2.1",
     "gulp-concat": "2.6.0",

--- a/app/templates/src/index.html
+++ b/app/templates/src/index.html
@@ -85,7 +85,7 @@
                 </p>
 
                 <section class="feature-list_item block">
-                    
+
                     <div class="feature-header">
                         <h1 class="feature-header_name">CF-Core</h1>
                         <a class="feature-header_docs"
@@ -256,7 +256,7 @@
                         </div>
                     </div>
                 </section>
-                
+
                 <section class="feature-list_item block block__padded-top block__border-top">
                     <div class="feature-header">
                         <h1 class="feature-header_name">CF-Forms</h1>
@@ -275,7 +275,7 @@
                         </div>
                     </div>
                 </section>
-                
+
                 <section class="feature-list_item block block__padded-top block__border-top">
                     <div class="feature-header">
                         <h1 class="feature-header_name">CF-Grid</h1>
@@ -365,7 +365,7 @@
                         </div>
                     </main>
                 </section>
-                
+
                 <section class="feature-list_item block block__padded-top block__border-top">
                     <div class="feature-header">
                         <h1 class="feature-header_name">CF-Pagination</h1>

--- a/app/templates/src/static/js/main.js
+++ b/app/templates/src/static/js/main.js
@@ -1,9 +1,10 @@
 'use strict';
 
-// The following line imports jQuery into your project. If you don't need jQuery, delete it.
+// The following line imports jQuery into your project.
+// If you don't need jQuery, delete it.
 global.$ = require( 'jquery' );
 
-// If you'd like to include cf-expandables (or any other node module in your project),
+// If you'd like to include cf-expandables (or any other node module),
 // run `npm install cf-expandables --save` and require() it in this file.
 <%
   var isExpandables = function( el ) {


### PR DESCRIPTION
## Changes

- Updated gulp to `3.9.1` from `3.9.0`.
- Removed extraneous whitespace from dependencies.
- Minor normalizing of spacing in parentheses.
- Fixed max line length warnings in linter.

## Review

- @contolini 
- @Scotchester 

## Notes

- https://github.com/cfpb/front-end/pull/111 needs to go in in order for the linter to pass.
