### PR TITLE
Updates eslint plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 - Updated gulp to `3.9.1` from `3.9.0`.
 - Fixed max line length warnings in linter.
 - Normalized spacing in parentheses.
+- Updated gulp-eslint to `3.x` and grunt-eslint to `19.x` for compatibility with
+  imported `.eslintrc` file.
 
 
 ## 2.0.0 - 2016-01-04

--- a/app/templates/grunt/_package.json
+++ b/app/templates/grunt/_package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-less": "1.0.1",
     "grunt-contrib-uglify": "0.9.1",
     "grunt-contrib-watch": "0.6.1",
-    "grunt-eslint": "17.2.0",
+    "grunt-eslint": "19.0.0",
     "grunt-legacssy": "0.4.0",
     "grunt-string-replace": "1.2.0",
     "grunt-topdoc": "0.3.0",

--- a/app/templates/gulp/_package.json
+++ b/app/templates/gulp/_package.json
@@ -30,7 +30,7 @@
     "gulp-concat": "2.6.0",
     "gulp-webpack": "1.5.0",
     "gulp-cssmin": "0.1.7",
-    "gulp-eslint": "2.0.0",
+    "gulp-eslint": "3.0.1",
     "gulp-header": "1.2.2",
     "gulp-imagemin": "2.3.0",
     "gulp-less": "3.0.3",


### PR DESCRIPTION
## Changes
- Updated gulp-eslint to `3.x` and grunt-eslint to `19.x` for compatibility with imported `.eslintrc` file.
## Testing
- `gulp lint` and `grunt lint` should not have an error in generated projects.
## Review
- @Scotchester 
- @contolini 
