### PR TITLE
Added option to run http-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
-## 2.3.0 - 2017-02-22
+## Unreleased
 
 ### Added
 - Added option to run http-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
+## 2.3.0 - 2017-02-22
+
+### Added
+- Added option to run http-server
 
 ## 2.2.2 - 2017-01-06
 

--- a/app/templates/grunt/_README.md
+++ b/app/templates/grunt/_README.md
@@ -67,8 +67,8 @@ grunt watch:cssjs
 After running `./setup.sh` or compiling with Grunt,
 you can view the site in a browser by opening `/dist/index.html`.
 Alternatively, you may want to use a local server with something like
-`http-server`. To do so, run `npm install http-server -g` and `npm start`
-(which starts the server and runs `grunt watch` to enabled auto-reloading).
+`http-server`. To do so, run `npm start` (which starts the server and runs
+`grunt watch` to enabled auto-reloading).
 
 ## Known issues
 

--- a/app/templates/grunt/_README.md
+++ b/app/templates/grunt/_README.md
@@ -67,7 +67,8 @@ grunt watch:cssjs
 After running `./setup.sh` or compiling with Grunt,
 you can view the site in a browser by opening `/dist/index.html`.
 Alternatively, you may want to use a local server with something like
-`http-server`. To do so, run `npm install http-server -g` and `npm start`.
+`http-server`. To do so, run `npm install http-server -g` and `npm start`
+(which starts the server and runs `grunt watch` to enabled auto-reloading).
 
 ## Known issues
 

--- a/app/templates/grunt/_README.md
+++ b/app/templates/grunt/_README.md
@@ -67,7 +67,7 @@ grunt watch:cssjs
 After running `./setup.sh` or compiling with Grunt,
 you can view the site in a browser by opening `/dist/index.html`.
 Alternatively, you may want to use a local server with something like
-`python -m SimpleHTTPServer`.
+`http-server`. To do so, run `npm install http-server -g` and `npm start`.
 
 ## Known issues
 

--- a/app/templates/grunt/_package.json
+++ b/app/templates/grunt/_package.json
@@ -41,6 +41,7 @@
     "grunt-legacssy": "0.4.0",
     "grunt-string-replace": "1.2.0",
     "grunt-topdoc": "0.3.0",
+    "http-server": "0.9.0",
     "jit-grunt": "0.9.1",
     "parallelshell": "2.0.0",
     "time-grunt": "1.2.1"

--- a/app/templates/grunt/_package.json
+++ b/app/templates/grunt/_package.json
@@ -12,6 +12,9 @@
     "type": "<%= props.repoType %>",
     "url": "<%= props.repoUrl %>"
   },
+    "scripts": {
+    "start": "parallelshell 'http-server ./dist/ -p7000' 'grunt watch'"
+  },
   "license": "<%= props.license %>",
   "keywords": [
     "<%= slugname %>"
@@ -39,6 +42,7 @@
     "grunt-string-replace": "1.2.0",
     "grunt-topdoc": "0.3.0",
     "jit-grunt": "0.9.1",
+    "parallelshell": "2.0.0",
     "time-grunt": "1.2.1"
   },
   "scripts": {

--- a/app/templates/gulp/_README.md
+++ b/app/templates/gulp/_README.md
@@ -53,7 +53,7 @@ gulp watch
 After running `./setup.sh` or compiling with Gulp,
 you can view the site in a browser by opening `/dist/index.html`.
 Alternatively, you may want to use a local server with something like
-`python -m SimpleHTTPServer`.
+`http-server`. To do so, run `npm install http-server -g` and `npm start`.
 
 ## Known issues
 

--- a/app/templates/gulp/_README.md
+++ b/app/templates/gulp/_README.md
@@ -53,8 +53,8 @@ gulp watch
 After running `./setup.sh` or compiling with Gulp,
 you can view the site in a browser by opening `/dist/index.html`.
 Alternatively, you may want to use a local server with something like
-`http-server`. To do so, run `npm install http-server -g` and `npm start`
-(which starts the server and runs `gulp watch` to enabled auto-reloading).
+`http-server`. To do so, run and `npm start` (which starts the server and
+runs `gulp watch` to enabled auto-reloading).
 
 ## Known issues
 

--- a/app/templates/gulp/_README.md
+++ b/app/templates/gulp/_README.md
@@ -53,7 +53,8 @@ gulp watch
 After running `./setup.sh` or compiling with Gulp,
 you can view the site in a browser by opening `/dist/index.html`.
 Alternatively, you may want to use a local server with something like
-`http-server`. To do so, run `npm install http-server -g` and `npm start`.
+`http-server`. To do so, run `npm install http-server -g` and `npm start`
+(which starts the server and runs `gulp watch` to enabled auto-reloading).
 
 ## Known issues
 

--- a/app/templates/gulp/_package.json
+++ b/app/templates/gulp/_package.json
@@ -44,6 +44,7 @@
     "gulp-sourcemaps": "1.5.2",
     "gulp-uglify": "1.4.1",
     "gulp-util": "3.0.6",
+    "http-server": "0.9.0",
     "jquery": "1.11.3",
     "parallelshell": "2.0.0",
     "pretty-hrtime": "1.0.0",

--- a/app/templates/gulp/_package.json
+++ b/app/templates/gulp/_package.json
@@ -12,6 +12,9 @@
     "type": "<%= props.repoType %>",
     "url": "<%= props.repoUrl %>"
   },
+  "scripts": {
+    "start": "parallelshell 'http-server ./dist/ -p7000' 'gulp watch'"
+  },
   "license": "<%= props.license %>",
   "keywords": [
     "<%= slugname %>"
@@ -42,6 +45,7 @@
     "gulp-uglify": "1.4.1",
     "gulp-util": "3.0.6",
     "jquery": "1.11.3",
+    "parallelshell": "2.0.0",
     "pretty-hrtime": "1.0.0",
     "require-dir": "0.3.0"
   }


### PR DESCRIPTION
Added http-server instructions to the readme, a small npm script, and a dependency for that script to make it easier to run a fresh project or test the generator and Capital Framework itself.

## Additions

- NPM script to start the server and watch tasks
- Parallelshell package for the NPM script
- Instructions on how to install and run the server.

## Testing

- Sym-link the generator by running `npm link` in the repo root
- In an empty test directory run `yo cf`, follow the prompts
- In a new terminal window at the test directory root, run `npm start`
- A server will start using port `7000` with a browsersync session on port `3000`

## Review

- @contolini 
- @anselmbradford 
- @Scotchester 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
